### PR TITLE
[WIP] Add support for more qualite zoom image

### DIFF
--- a/js/enhance.js
+++ b/js/enhance.js
@@ -113,14 +113,20 @@
   Zoom.OFFSET = 80 //margins
 
   Zoom.prototype.zoomImage = function () {
-    var img = document.createElement('img')
+    var img = document.createElement('img');
+
     img.onload = $.proxy(function () {
-      this._fullHeight = Number(img.height)
-      this._fullWidth = Number(img.width)
-      this._zoomOriginal()
-    }, this)
-    img.src = this._targetImage.src
-  }
+      this._fullHeight = Number(img.height);
+      this._fullWidth = Number(img.width);
+      this._targetImage.src = img.src;
+        
+      this._zoomOriginal();
+    }, this);
+
+    img.src = this._targetImage.hasAttribute('data-zoom-src')
+        ? this._targetImage.getAttribute('data-zoom-src')
+        : this._targetImage.src;
+  };
 
   Zoom.prototype._zoomOriginal = function () {
     this._targetImageWrap           = document.createElement('div')


### PR DESCRIPTION
Hi, I was looking for a way how to display only a small image to speed up the website and display a bigger one when image is clicked. Didn't find anything but after hour I came up with this solution. If u find it useful feel free to merge it :) If not never mind. 

Usually is better to display a thumbnail with actual thumbnail dimensions. Let's say 520px x 320px (image original size no browser shrinking etc, let's say 140KB). 

Enhance.js is currently just zooming this picture. 

My changes make it possible when zooming a picture to display bigger, prepared, more qualite image. Let's say 1000px x 720px (400kb).

Usage:

`<img src='http://thumbnail.url' data-zoom-src='http://original.big.image.url' data-action='zoom' />`
